### PR TITLE
remove static members from AnalogyMessageProducer

### DIFF
--- a/Analogy.LogServer.Clients/NetCore/AnalogyMessageProducer.cs
+++ b/Analogy.LogServer.Clients/NetCore/AnalogyMessageProducer.cs
@@ -19,7 +19,6 @@ namespace Analogy.LogServer.Clients
         public event EventHandler<string> OnError;
         private static readonly int ProcessId = Process.GetCurrentProcess().Id;
         private static readonly string ProcessName = Process.GetCurrentProcess().ProcessName;
-        private static Analogy.AnalogyClient client { get; set; }
         private GrpcChannel channel;
         private AsyncClientStreamingCall<AnalogyGRPCLogMessage, AnalogyMessageReply> stream;
         private bool connected = true;
@@ -37,9 +36,8 @@ namespace Analogy.LogServer.Clients
         {
             try
             {
-                // channel = GrpcChannel.ForAddress("http://localhost:6000");
                 channel = GrpcChannel.ForAddress(address);
-                client = new Analogy.AnalogyClient(channel);
+                var client = new Analogy.AnalogyClient(channel);
                 stream = client.SubscribeForPublishingMessages();
             }
             catch (Exception e)

--- a/Analogy.LogServer.Clients/NetCore/AnalogyMessageProducer.cs
+++ b/Analogy.LogServer.Clients/NetCore/AnalogyMessageProducer.cs
@@ -23,7 +23,7 @@ namespace Analogy.LogServer.Clients
         private GrpcChannel channel;
         private AsyncClientStreamingCall<AnalogyGRPCLogMessage, AnalogyMessageReply> stream;
         private bool connected = true;
-        private static readonly SemaphoreSlim _semaphoreSlim = new SemaphoreSlim(1);
+        private readonly SemaphoreSlim _semaphoreSlim = new SemaphoreSlim(1, 1);
 
         static AnalogyMessageProducer()
         {


### PR DESCRIPTION
- Avoiding concurrent targets locking eachother for no reason
- Making disconnect with subsequent reconnect possible